### PR TITLE
Add support for any page with __NEWSECTIONLINK__

### DIFF
--- a/UltiBlocksAutoMod/remindmebot.py
+++ b/UltiBlocksAutoMod/remindmebot.py
@@ -56,7 +56,7 @@ def iteration(site):
             if now is None:
                 now=i
             # Filter to only revisions on talk pages (odd numbered namespaces)
-            if e["ns"] % 2 == 1:
+            if e["ns"] % 2 == 1 or "__NEWSECTIONLINK__" in page.text:
                 # Get the page associated with the revision
                 page = pywikibot.Page(site, e["title"])
                 # Check if this edit was page creation. If so, the whole page

--- a/UltiBlocksAutoMod/remindmebot.py
+++ b/UltiBlocksAutoMod/remindmebot.py
@@ -55,10 +55,10 @@ def iteration(site):
             # Set the latest revision variable if it hasn't been set
             if now is None:
                 now=i
+            # Get the page associated with the revision
+            page = pywikibot.Page(site, e["title"])
             # Filter to only revisions on talk pages (odd numbered namespaces)
             if e["ns"] % 2 == 1 or "__NEWSECTIONLINK__" in page.text:
-                # Get the page associated with the revision
-                page = pywikibot.Page(site, e["title"])
                 # Check if this edit was page creation. If so, the whole page
                 # is added content.
                 if e["old_revid"]==0:


### PR DESCRIPTION
Enhance functionality to include pages containing the NEWSECTIONLINK magic word in the filtering process for revisions on pages.

This adds support for the community portal, bot requests, and admin elections